### PR TITLE
Fix invalid dimension

### DIFF
--- a/src/basic/Popup/index.js
+++ b/src/basic/Popup/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import { View, Text, TouchableOpacity, StyleSheet, Image, Animated, Dimensions, Alert } from 'react-native'
 
-const WIDTH = Dimensions.get('window').width
-const HEIGHT = Dimensions.get('window').height
+const WIDTH = Dimensions.get('screen').width
+const HEIGHT = Dimensions.get('screen').height
 
 class Popup extends Component {
 	static popupInstance

--- a/src/basic/Toast/index.js
+++ b/src/basic/Toast/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { View, Animated, Text, StyleSheet, Image, Dimensions } from 'react-native'
 
-const { height } = Dimensions.get('window')
+const { height } = Dimensions.get('screen')
 
 class Toast extends Component {
     static toastInstance


### PR DESCRIPTION
Dimensions.get('window').width
`{"fontScale": 1, "height": 850.9090909090909, "scale": 2.75, "width": 392.72727272727275}`

Dimensions.get('screen').width
`{"fontScale": 1, "height": 776, "scale": 2.75, "width": 392.72727272727275}`

Getting screen dimension causes blank part on popup container and toast container on screen bottom in android (mentioned at #7 )